### PR TITLE
Improve: invalid URLs, unnecessary/not-so-appropriate operations

### DIFF
--- a/docs/html/index.html
+++ b/docs/html/index.html
@@ -71,7 +71,7 @@ $(function() {
 <p>It is recommended to run this package on <b>ROS2 Foxy</b>.</p>
 <hr  />
  <h1>Full Documentation/Wiki</h1>
-<p><a href="https://easy-manipulation-deployment-tanjpg.readthedocs.io/">Check out the full ReadTheDocs documentation here</a></p>
+<p><a href="https://easy-manipulation-deployment-docs.readthedocs.io/">Check out the full ReadTheDocs documentation here</a></p>
 <hr  />
  <h1>Acknowledgements</h1>
 <p>We would like to acknowledge the Singapore government for their vision and support to start this ambitious research and development project, "Accelerating Open Source Technologies for Cross Domain Adoption through the Robot Operating System". The project is supported by Singapore National Robotics Programme (NRP).</p>

--- a/docs/latex/index.tex
+++ b/docs/latex/index.tex
@@ -7,7 +7,7 @@ It is recommended to run this package on {\bfseries{R\+O\+S2 Foxy}}.
 \DoxyHorRuler{0}
  \doxysection*{Full Documentation/\+Wiki}
 
-\href{https://easy-manipulation-deployment-tanjpg.readthedocs.io/}{\texttt{ Check out the full Read\+The\+Docs documentation here}}
+\href{https://easy-manipulation-deployment-docs.readthedocs.io/}{\texttt{ Check out the full Read\+The\+Docs documentation here}}
 
 \DoxyHorRuler{0}
  \doxysection*{Acknowledgements}

--- a/docs/sphinx/source/emd_packages/grasp_planner/grasp_planner_input.rst
+++ b/docs/sphinx/source/emd_packages/grasp_planner/grasp_planner_input.rst
@@ -30,7 +30,7 @@ The EMD Grasp Planner also supports output from the `easy_perception_deployment 
 
 Currently the EMD Grasp Planner supports both **Object Localization** and **Object Tracking** outputs from EPD Precision level 3.
 
-To understand more about the output messages from EPD, do visit the `EPD documentation <https://easy-perception-deployment.readthedocs.io/en/latest/>`_
+To understand more about the output messages from EPD, do visit the `EPD documentation <https://epd-docs.readthedocs.io/en/latest/>`_
 
 
 Which EMD Workflow to choose?
@@ -85,7 +85,7 @@ Greater hardware requriements: EPD Workflow
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Due to the higher hardware limitations for deploying of deep learning models, hardware requirements will be higher for the EPD workflow.
-Check the `easy_perception_deployment documentation <https://easy-perception-deployment.readthedocs.io/en/latest/>`_
+Check the `easy_perception_deployment documentation <https://epd-docs.readthedocs.io/en/latest/>`_
 for a more comprehensive hardware requirement specifications.
 
 Which EMD Workflow to choose (TLDR)?

--- a/docs/sphinx/source/emd_packages/grasp_planner/grasp_planner_parameters_general_epd.rst
+++ b/docs/sphinx/source/emd_packages/grasp_planner/grasp_planner_parameters_general_epd.rst
@@ -60,7 +60,7 @@ if :code:`true`, EPD Precision Level 3, Object Tracking will be taken as input.
 if :code:`false`, EPD Precision Level 2, Object Localization will be taken as input.
 
 To understand more about the different precision levels, visit the
-`easy_perception_deployment documentation <https://easy-perception-deployment.readthedocs.io/en/latest/>`_
+`easy_perception_deployment documentation <https://epd-docs.readthedocs.io/en/latest/>`_
 
 To find out more about the Precision Level ROS2 message differences: :ref:`grasp_planner_input` 
 

--- a/docs/sphinx/source/getting_started/download_instructions.rst
+++ b/docs/sphinx/source/getting_started/download_instructions.rst
@@ -60,15 +60,13 @@ Installing only the Workcell Builder
 
    git clone https://github.com/ros-industrial/easy_manipulation_deployment.git
    
-   find ./easy_manipulation_deployment -mindepth 1 ! -regex '^./easy_manipulation_deployment/workcell_builder\(/.*\)?' -delete
-
    cd ~/workcell_ws
    
    source /opt/ros/foxy/setup.bash
    
    rosdep install --from-paths src --ignore-src -yr --rosdistro "${ROS_DISTRO}"
 
-   colcon build
+   colcon build --packages-up-to workcell_builder
 
    source install/setup.bash
 

--- a/docs/sphinx/source/getting_started/download_instructions.rst
+++ b/docs/sphinx/source/getting_started/download_instructions.rst
@@ -60,12 +60,6 @@ Installing only the Workcell Builder
 
    git clone https://github.com/ros-industrial/easy_manipulation_deployment.git
    
-   mv easy_manipulation_deployment/assets/ .
-
-   mv easy_manipulation_deployment/scenes/ .
-
-   mv easy_manipulation_deployment/easy_manipulation_deployment/workcell_builder ./easy_manipulation_deployment
-   
    find ./easy_manipulation_deployment -mindepth 1 ! -regex '^./easy_manipulation_deployment/workcell_builder\(/.*\)?' -delete
 
    cd ~/workcell_ws
@@ -88,12 +82,6 @@ Installing entire Easy Manipulation Deployment package
    cd ~/workcell_ws/src
 
    git clone https://github.com/ros-industrial/easy_manipulation_deployment.git
-   
-   mv easy_manipulation_deployment/assets/ .
-
-   mv easy_manipulation_deployment/scenes/ .
-
-   mv easy_manipulation_deployment/easy_manipulation_deployment/workcell_builder ./easy_manipulation_deployment
    
    cd ~/workcell_ws
    


### PR DESCRIPTION
# Issues aimed at
- Some URLs either don't exist or are invalid.
   - `easy-manipulation-deployment-tanjpg.readthedocs.io` looks someone's private repo, looks different from [easy-manipulation-deployment-docs.readthedocs.io](https://easy-manipulation-deployment-docs.readthedocs.io), which is linked from github dev repo.
   - https://easy-perception-deployment.readthedocs.io doesn't seem to exist.
- Some operations are not so appropriate (removing packages that you're not building).

# Review items
- [ ] Blocked by https://github.com/ros-industrial/easy_manipulation_deployment/pull/18